### PR TITLE
Added support for (optional...), using "of" and splitting ingredient and action

### DIFF
--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/ingreedy/version', __FILE__)
 Gem::Specification.new do |s|
  s.name        = "ingreedy"
  s.version     = Ingreedy::VERSION
- s.authors     = ["Ian C. Anderson"]
+ s.authors     = ["Ian C. Anderson", "Torgny Bjers"]
  s.email       = ["anderson.ian.c@gmail.com"]
 
  s.summary     = "Recipe parser"

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -102,11 +102,11 @@ module Ingreedy
       result[:ingredient] = parslet_output[:ingredient].to_s.lstrip.rstrip #TODO cheating
 
       if parslet_output[:action]
-        result[:action] = parslet_output[:action]
+        result[:action] = parslet_output[:action].to_s
       end
 
       if parslet_output[:optional]
-        result[:optional] = parslet_output[:optional]
+        result[:optional] = parslet_output[:optional].to_s
       end
 
       result

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -45,10 +45,6 @@ module Ingreedy
       str(')').maybe >> whitespace
     end
 
-    rule(:ingredient) do
-      any.repeat
-    end
-
     rule(:unit_and_whitespace) do
       unit.as(:unit) >> whitespace
     end

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -73,7 +73,7 @@ module Ingreedy
     rule(:ingredient_addition) do
       # e.g. 1/2 (12 oz) can black beans
       optional_instructions.maybe >>
-      amount >>
+      amount.maybe >>
       whitespace.maybe >>
       container_size.maybe >>
       unit_and_whitespace.maybe >>
@@ -93,7 +93,9 @@ module Ingreedy
 
       parslet_output = super(original_query)
 
-      result[:amount] = rationalize_total_amount(parslet_output[:amount], parslet_output[:container_amount])
+      if (maybe_amount = rationalize_total_amount(parslet_output[:amount], parslet_output[:container_amount]))
+        result[:amount] = maybe_amount
+      end
 
       if parslet_output[:unit]
         result[:unit] = convert_unit_variation_to_canonical(parslet_output[:unit].to_s)
@@ -127,6 +129,7 @@ module Ingreedy
     end
 
     def rationalize_amount(amount, capture_key_prefix = '')
+      return nil unless amount
       integer = amount["#{capture_key_prefix}integer_amount".to_sym]
       integer &&= integer.to_s
 

--- a/lib/ingreedy/unit_variation_mapper.rb
+++ b/lib/ingreedy/unit_variation_mapper.rb
@@ -30,24 +30,24 @@ module Ingreedy
     def self.build_variations_map
       #TODO prioritize the un-abbreviated versions
       {
-        ['cups', 'cup', 'c.', 'c'] => :cup,
-        ["fl. oz.", "fl oz", "fluid ounce", "fluid ounces"] => :fluid_ounce,
-        ["gal", "gal.", "gallon", "gallons"] => :gallon,
-        ["oz", "oz.", "ounce", "ounces"] => :ounce,
-        ["pt", "pt.", "pint", "pints"] => :pint,
-        ["lb", "lb.", "pound", "pounds"] => :pound,
-        ["qt", "qt.", "qts", "qts.", "quart", "quarts"] => :quart,
-        ["tbsp.", "tbsp", "T", "T.", "tablespoon", "tablespoons", "tbs.", "tbs"] => :tablespoon,
-        ["tsp.", "tsp", "t", "t.", "teaspoon", "teaspoons"] => :teaspoon,
-        ["g", "g.", "gr", "gr.", "gram", "grams"] => :gram,
-        ["kg", "kg.", "kilogram", "kilograms"] => :kilogram,
-        ["l", "l.", "liter", "liters"] => :liter,
-        ["mg", "mg.", "milligram", "milligrams"] => :milligram,
-        ["ml", "ml.", "milliliter", "milliliters"] => :milliliter,
-        ["pinch", "pinches"] => :pinch,
-        ["dash", "dashes"] => :dash,
-        ["touch", "touches"] => :touch,
-        ["handful", "handfuls"] => :handful
+        ["cups", "cup", "c.", "c"] => :cup,
+        ["fluid ounces", "fluid ounce", "fl. oz.", "fl oz"] => :fluid_ounce,
+        ["gallons", "gallon", "gal.", "gal"] => :gallon,
+        ["ounces", "ounce", "oz.", "oz"] => :ounce,
+        ["pints", "pint", "pt.", "pt"] => :pint,
+        ["pounds", "pound", "lb.", "lb"] => :pound,
+        ["quarts", "quart", "qts.", "qts", "qt.", "qt"] => :quart,
+        ["tablespoons", "tablespoon", "tbsp.", "tbsp", "tbs.", "tbs", "T", "T."] => :tablespoon,
+        ["teaspoons", "teaspoon", "tsp.", "tsp", "t", "t."] => :teaspoon,
+        ["grams", "gram", "gr.", "gr", "g.", "g"] => :gram,
+        ["kilograms", "kilogram", "kg.", "kg"] => :kilogram,
+        ["liters", "liter", "l.", "l"] => :liter,
+        ["milligrams", "milligram", "mg.", "mg"] => :milligram,
+        ["milliliters", "milliliter", "ml.", "ml"] => :milliliter,
+        ["pinches", "pinch"] => :pinch,
+        ["dashes", "dash"] => :dash,
+        ["touches", "touch"] => :touch,
+        ["handfuls", "handful"] => :handful
       }
     end
 

--- a/lib/ingreedy/unit_variation_mapper.rb
+++ b/lib/ingreedy/unit_variation_mapper.rb
@@ -35,7 +35,7 @@ module Ingreedy
         ["gallons", "gallon", "gal.", "gal"] => :gallon,
         ["ounces", "ounce", "oz.", "oz"] => :ounce,
         ["pints", "pint", "pt.", "pt"] => :pint,
-        ["pounds", "pound", "lb.", "lb"] => :pound,
+        ["pounds", "pound", "lbs.", "lbs", "lb.", "lb"] => :pound,
         ["quarts", "quart", "qts.", "qts", "qt.", "qt"] => :quart,
         ["tablespoons", "tablespoon", "tbsp.", "tbsp", "tbs.", "tbs", "T", "T."] => :tablespoon,
         ["teaspoons", "teaspoon", "tsp.", "tsp", "t", "t."] => :teaspoon,

--- a/lib/ingreedy/version.rb
+++ b/lib/ingreedy/version.rb
@@ -1,4 +1,4 @@
 module Ingreedy
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end
 

--- a/lib/ingreedy/version.rb
+++ b/lib/ingreedy/version.rb
@@ -1,4 +1,4 @@
 module Ingreedy
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end
 

--- a/lib/ingreedy/version.rb
+++ b/lib/ingreedy/version.rb
@@ -1,4 +1,4 @@
 module Ingreedy
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end
 

--- a/lib/ingreedy/version.rb
+++ b/lib/ingreedy/version.rb
@@ -1,4 +1,4 @@
 module Ingreedy
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end
 

--- a/lib/ingreedy/version.rb
+++ b/lib/ingreedy/version.rb
@@ -1,4 +1,4 @@
 module Ingreedy
-  VERSION = '0.0.8'
+  VERSION = '0.0.5'
 end
 

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -290,3 +290,19 @@ describe "with of before ingredient" do
     @ingreedy.ingredient.should == "potatoes"
   end
 end
+
+describe "ingredient without amount or units" do
+  before(:all) { @ingreedy = Ingreedy.parse "salt + pepper to taste" }
+
+  it "should have a nil amount" do
+    @ingreedy.amount.should be_nil
+  end
+
+  it "should have a nil unit" do
+    @ingreedy.unit.should be_nil
+  end
+
+  it "should have the correct ingredient" do
+    @ingreedy.ingredient.should == "salt + pepper to taste"
+  end
+end

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -225,12 +225,68 @@ describe "without units" do
   end
 
   it "should have the correct ingredient" do
-    @ingreedy.ingredient.should == "eggs, lightly beaten"
+    @ingreedy.ingredient.should == "eggs"
   end
 end
 
 describe "ingredient formatting" do
   it "should not have any preceding or trailing whitespace" do
     Ingreedy.parse("1 cup flour ").ingredient.should == "flour"
+  end
+end
+
+describe "with leading optional" do
+  before(:all) { @ingreedy = Ingreedy.parse "(optional, if you have it at hand) 3 eggs, lightly beaten" }
+
+  it "should have an amount of 3" do
+    @ingreedy.amount.should == 3
+  end
+
+  it "should have a nil unit" do
+    @ingreedy.unit.should be_nil
+  end
+
+  it "should have the correct ingredient" do
+    @ingreedy.ingredient.should == "eggs"
+  end
+
+  it "should have the correct optional" do
+    @ingreedy.optional.should == "optional, if you have it at hand"
+  end
+end
+
+describe "ingredient with action" do
+  before(:all) { @ingreedy = Ingreedy.parse "3 eggs, lightly beaten" }
+
+  it "should have an amount of 3" do
+    @ingreedy.amount.should == 3
+  end
+
+  it "should have a nil unit" do
+    @ingreedy.unit.should be_nil
+  end
+
+  it "should have the correct ingredient" do
+    @ingreedy.ingredient.should == "eggs"
+  end
+
+  it "should have the correct action" do
+    @ingreedy.action.should == "lightly beaten"
+  end
+end
+
+describe "with of before ingredient" do
+  before(:all) { @ingreedy = Ingreedy.parse "3 cups of potatoes" }
+
+  it "should have an amount of 3" do
+    @ingreedy.amount.should == 3
+  end
+
+  it "should be a cup unit" do
+    @ingreedy.unit.should == :cup
+  end
+
+  it "should have the correct ingredient" do
+    @ingreedy.ingredient.should == "potatoes"
   end
 end


### PR DESCRIPTION
This is a great little gem, and I just wanted to contribute my additions upstream. I have added support for the following new elements in an ingredient line:

```
(optional, if you have it at hand) 1/4 c. of white wine
3 cups of russet potatoes, cubed
```

As you can see, ingredients now support the usage of the word "of" as well as extracting the `optional` clause and separating out the actions that are needed for a specific ingredient.

What do you think?