### PR TITLE
Support for multiple locales and custom units

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ print result.ingredient
   #=> "potatoes"
 ```
 
+### I18n and custom dictionaries
+
+```ruby
+Ingreedy.dictionaries[:fr] = { 
+  units: { dash: ['pincée'] }, 
+  numbers: { 'une' => 1 }, 
+  prepositions: ['de'] 
+}
+
+Ingreedy.locale = :fr # Also automatically follows I18n.locale if available
+
+result = Ingreedy.parse('une pincée de sucre')
+print result.amount
+  #=> 1.0
+print result.unit
+  #=> :dash
+print result.ingredient
+  #=> "sucre"
+```
+
 [Live demo](http://hangryingreedytest.herokuapp.com/)
 
 # Pieces of Flair

--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
  s.homepage    = "http://github.com/iancanderson/ingreedy"
 
  s.add_dependency 'parslet', '~> 1.5.0'
- s.add_dependency 'numbers_in_words', '~> 0.2.0'
 
  s.add_development_dependency 'rake', '~> 0.9'
  s.add_development_dependency 'rspec', '~> 2.11.0'

--- a/lib/ingreedy.rb
+++ b/lib/ingreedy.rb
@@ -2,12 +2,19 @@ path = File.expand_path(File.join(File.dirname(__FILE__), 'ingreedy'))
 
 require File.join(path, 'case_insensitive_parser')
 require File.join(path, 'ingreedy_parser')
+require File.join(path, 'dictionary_collection')
 
 module Ingreedy
   class << self
+    attr_accessor :locale
+
     def parse(query)
       parser = Parser.new(query)
       parser.parse
+    end
+
+    def dictionaries
+      @dictionaries ||= DictionaryCollection.new
     end
   end
 end

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -1,5 +1,4 @@
 require 'parslet'
-require 'numbers_in_words'
 
 module Ingreedy
 
@@ -32,27 +31,23 @@ module Ingreedy
       (integer >> match('/') >> integer).as(capture_key(:fraction_amount))
     end
 
-    rule(:english_digit) do
-      english_digits.map { |d| stri(d) }.inject(:|)
+    rule(:word_digit) do
+      word_digits.map { |d| stri(d) }.inject(:|) || any
     end
 
     rule(:amount) do
       fraction |
         float.as(capture_key(:float_amount)) |
         integer.as(capture_key(:integer_amount)) |
-        english_digit.as(capture_key(:word_integer_amount))
+        word_digit.as(capture_key(:word_integer_amount))
     end
 
     root(:amount)
 
     private
 
-    def english_digits
-      (1..12).map do |n|
-        NumbersInWords::ToWord.new(
-          n, NumbersInWords.language
-        ).in_words
-      end
+    def word_digits
+      Ingreedy.dictionaries.current.numbers.keys
     end
 
   end

--- a/lib/ingreedy/dictionaries/en.yml
+++ b/lib/ingreedy/dictionaries/en.yml
@@ -1,0 +1,135 @@
+:units:
+  :cup:
+    - "cups"
+    - "cup"
+    - "c."
+    - "c"
+  :fluid_ounce:
+    - "fl. oz."
+    - "fl oz"
+    - "fluid ounce"
+    - "fluid ounces"
+  :gallon:
+    - "gal"
+    - "gal."
+    - "gallon"
+    - "gallons"
+  :ounce:
+    - "oz"
+    - "oz."
+    - "ounce"
+    - "ounces"
+  :pint:
+    - "pt"
+    - "pt."
+    - "pint"
+    - "pints"
+  :pound:
+    - "lb"
+    - "lb."
+    - "pound"
+    - "pounds"
+  :quart:
+    - "qt"
+    - "qt."
+    - "qts"
+    - "qts."
+    - "quart"
+    - "quarts"
+  :tablespoon:
+    - "tbsp."
+    - "tbsp"
+    - "T"
+    - "T."
+    - "tablespoon"
+    - "tablespoons"
+    - "tbs."
+    - "tbs"
+  :teaspoon:
+    - "tsp."
+    - "tsp"
+    - "t"
+    - "t."
+    - "teaspoon"
+    - "teaspoons"
+  :gram:
+    - "g"
+    - "g."
+    - "gr"
+    - "gr."
+    - "gram"
+    - "grams"
+  :kilogram:
+    - "kg"
+    - "kg."
+    - "kilogram"
+    - "kilograms"
+  :liter:
+    - "l"
+    - "l."
+    - "liter"
+    - "liters"
+  :milligram:
+    - "mg"
+    - "mg."
+    - "milligram"
+    - "milligrams"
+  :milliliter:
+    - "ml"
+    - "ml."
+    - "milliliter"
+    - "milliliters"
+  :pinch:
+    - "pinch"
+    - "pinches"
+  :dash:
+    - "dash"
+    - "dashes"
+  :touch:
+    - "touch"
+    - "touches"
+  :handful:
+    - "handful"
+    - "handfuls"
+  :stick:
+    - "stick"
+    - "sticks"
+  :clove:
+    - "cloves"
+    - "clove"
+  :can:
+    - "cans"
+    - "can"
+:numbers:
+  a: 1
+  an: 1
+  zero: 0
+  one: 1
+  two: 2
+  three: 3
+  four: 4
+  five: 5
+  six: 6
+  seven: 7
+  eight: 8
+  nine: 9
+  ten: 10
+  eleven: 11
+  twelve: 12
+  thirteen: 13
+  fourteen: 14
+  fifteen: 15
+  sixteen: 16
+  seventeen: 17
+  eighteen: 18
+  nineteen: 19
+  twenty: 20
+  thirty: 30
+  forty: 40
+  fifty: 50
+  sixty: 60
+  seventy: 70
+  eighty: 80
+  ninety: 9
+:prepositions:
+  - "of"

--- a/lib/ingreedy/dictionary.rb
+++ b/lib/ingreedy/dictionary.rb
@@ -1,0 +1,10 @@
+module Ingreedy
+  class Dictionary
+    attr_reader :units, :numbers, :prepositions
+
+    def initialize(units: {}, numbers: {}, prepositions: [])
+      @units, @numbers, @prepositions = units, numbers, prepositions
+      raise 'No units found in dictionary' if @units.empty?
+    end
+  end
+end

--- a/lib/ingreedy/dictionary.rb
+++ b/lib/ingreedy/dictionary.rb
@@ -2,9 +2,10 @@ module Ingreedy
   class Dictionary
     attr_reader :units, :numbers, :prepositions
 
-    def initialize(units: {}, numbers: {}, prepositions: [])
-      @units, @numbers, @prepositions = units, numbers, prepositions
-      raise 'No units found in dictionary' if @units.empty?
+    def initialize(entries = {})
+      @units = entries[:units] || raise('No units found in dictionary')
+      @numbers = entries[:numbers] || {}
+      @prepositions = entries[:prepositions] || []
     end
   end
 end

--- a/lib/ingreedy/dictionary_collection.rb
+++ b/lib/ingreedy/dictionary_collection.rb
@@ -1,0 +1,35 @@
+require 'yaml'
+require_relative 'dictionary'
+
+module Ingreedy
+  class DictionaryCollection
+    def initialize
+      @collection = {}
+    end
+
+    def []=(locale, attributes)
+      @collection[locale] = Dictionary.new(attributes)
+    end
+
+    def current
+      @collection[locale] ||= Dictionary.new load_yaml(locale)
+    end
+
+    private
+
+    def locale
+      Ingreedy.locale || i18n_gem_locale || :en
+    end
+
+    def i18n_gem_locale
+      I18n.locale if defined?(I18n)
+    end
+
+    def load_yaml(locale)
+      path = File.expand_path(File.join(File.dirname(__FILE__), 'dictionaries', "#{locale}.yml"))
+      YAML.load_file(path)
+    rescue Errno::ENOENT
+      raise "No dictionary found for :#{locale} locale"
+    end
+  end
+end

--- a/lib/ingreedy/rationalizer.rb
+++ b/lib/ingreedy/rationalizer.rb
@@ -1,5 +1,3 @@
-require 'numbers_in_words'
-
 module Ingreedy
 
   class Rationalizer
@@ -35,9 +33,7 @@ module Ingreedy
     private
 
     def rationalize_word
-      NumbersInWords::ToNumber.new(
-        @word, NumbersInWords.language
-      ).in_numbers.to_r
+      Ingreedy.dictionaries.current.numbers[@word]
     end
 
   end

--- a/lib/ingreedy/unit_parser.rb
+++ b/lib/ingreedy/unit_parser.rb
@@ -4,12 +4,16 @@ module Ingreedy
     include CaseInsensitiveParser
 
     rule(:unit) do
-      UnitVariationMapper.all_variations.map { |variation|
-        str(variation) | stri(variation)
-      }.reduce(:|)
+      unit_variations.map { |var| str(var) | stri(var) }.reduce(:|)
     end
 
     root :unit
+
+    private
+
+    def unit_variations
+      UnitVariationMapper.all_variations
+    end
 
   end
 

--- a/lib/ingreedy/unit_variation_mapper.rb
+++ b/lib/ingreedy/unit_variation_mapper.rb
@@ -5,51 +5,27 @@ module Ingreedy
       # Return these in order of size, descending
       # That way, the longer versions will try to be parsed first, then the shorter versions
       # e.g. so '1 cup flour' will be parsed as 'cup' instead of 'c'
-      @@all_variations ||= variations_map.keys.flatten.sort { |a, b| b.length <=> a.length }
+      variations_map.values.flatten.sort { |a, b| b.length <=> a.length }
     end
 
     def self.unit_from_variation(variation)
-      hash_entry_as_array = variations_map.detect { |variations, unit| variations.include?(variation) }
+      return if variations_map.empty?
+      hash_entry_as_array = variations_map.detect { |unit, variations| variations.include?(variation) }
 
       if hash_entry_as_array
-        hash_entry_as_array.last
+        hash_entry_as_array.first
       else
         # try again with the variation downcased
         # this is a hacky way to deal with the abbreviations for teaspoon and tablespoon
-        hash_entry_as_array = variations_map.detect { |variations, unit| variations.include?(variation.downcase) }
-        hash_entry_as_array.last
+        hash_entry_as_array = variations_map.detect { |unit, variations| variations.include?(variation.downcase) }
+        hash_entry_as_array.first
       end
     end
 
     private
 
     def self.variations_map
-      @@variations_map ||= build_variations_map
+      Ingreedy.dictionaries.current.units
     end
-
-    def self.build_variations_map
-      #TODO prioritize the un-abbreviated versions
-      {
-        ['cups', 'cup', 'c.', 'c'] => :cup,
-        ["fl. oz.", "fl oz", "fluid ounce", "fluid ounces"] => :fluid_ounce,
-        ["gal", "gal.", "gallon", "gallons"] => :gallon,
-        ["oz", "oz.", "ounce", "ounces"] => :ounce,
-        ["pt", "pt.", "pint", "pints"] => :pint,
-        ["lb", "lb.", "pound", "pounds"] => :pound,
-        ["qt", "qt.", "qts", "qts.", "quart", "quarts"] => :quart,
-        ["tbsp.", "tbsp", "T", "T.", "tablespoon", "tablespoons", "tbs.", "tbs"] => :tablespoon,
-        ["tsp.", "tsp", "t", "t.", "teaspoon", "teaspoons"] => :teaspoon,
-        ["g", "g.", "gr", "gr.", "gram", "grams"] => :gram,
-        ["kg", "kg.", "kilogram", "kilograms"] => :kilogram,
-        ["l", "l.", "liter", "liters"] => :liter,
-        ["mg", "mg.", "milligram", "milligrams"] => :milligram,
-        ["ml", "ml.", "milliliter", "milliliters"] => :milliliter,
-        ["pinch", "pinches"] => :pinch,
-        ["dash", "dashes"] => :dash,
-        ["touch", "touches"] => :touch,
-        ["handful", "handfuls"] => :handful
-      }
-    end
-
   end
 end

--- a/spec/ingreedy/rationalizer_spec.rb
+++ b/spec/ingreedy/rationalizer_spec.rb
@@ -33,5 +33,12 @@ describe Ingreedy::Rationalizer do
     end
   end
 
+  context 'with the word a or an' do
+    it 'gives back a rational' do
+      subject.rationalize(word: 'a').should == '1'.to_r
+      subject.rationalize(word: 'an').should == '1'.to_r
+    end
+  end
+
 end
 


### PR DESCRIPTION
So...this is one of those slightly larger PRs that I imagine will give a repo maintainer pause :sweat_smile:, so not sure if I can convince you to pull it in, but will at least have a go at "selling it" to you. :relaxed:

Basically the main thing it does is allow Ingreedy to work in multiple languages with custom unit dictionaries.

The way it works is as described in the [addition to the readme file](https://github.com/balvig/ingreedy/blob/d462f4ea68f6c3b2a7b88e485c760cf0249c34b2/README.md#i18n-and-custom-dictionaries):

```ruby
Ingreedy.dictionaries[:fr] = { 
  units: { dash: ['pincée'] }, 
  numbers: { 'une' => 1 }, 
  prepositions: ['de'] 
}

Ingreedy.locale = :fr # Also automatically follows I18n.locale if available

result = Ingreedy.parse('une pincée de sucre')
print result.amount #=> 1.0
print result.unit #=> :dash
print result.ingredient #=> "sucre"
```

Along with this functionality comes a number of, I think, great "fringe benefits":

- Built-in dictionaries can be defined in yaml without touching code (see the [/dictionaries](https://github.com/balvig/ingreedy/tree/d462f4ea68f6c3b2a7b88e485c760cf0249c34b2/lib/ingreedy/dictionaries) folder). Hopefully this will make it easy for others to contribute more units and languages and make Ingreedy smarter! :bowtie: 
- Adds concept of "prepositions" to handle cases such as "a dash _of_ salt" (mentioned in #12)
- Adds support for "reverse format", ie: "Flour 200g"
- Solves "can problem" (mentioned in #3, covered [here](https://github.com/balvig/ingreedy/blob/d462f4ea68f6c3b2a7b88e485c760cf0249c34b2/spec/ingreedy_spec.rb#L196-L206))
- Replaces unmaintained [number_in_words gem](https://github.com/markburns/numbers_in_words) with simple hash lookup for parsing words into numbers

Hoping this seems like a good idea!
In any case thanks for creating this awesome gem, it has been a great a help on the projects I'm currently working on. :yum: 
