### PR TITLE
support conversion of uppercase words to numbers

### DIFF
--- a/lib/ingreedy/rationalizer.rb
+++ b/lib/ingreedy/rationalizer.rb
@@ -33,7 +33,7 @@ module Ingreedy
     private
 
     def rationalize_word
-      Ingreedy.dictionaries.current.numbers[@word]
+      Ingreedy.dictionaries.current.numbers[@word.downcase]
     end
 
   end

--- a/spec/ingreedy/rationalizer_spec.rb
+++ b/spec/ingreedy/rationalizer_spec.rb
@@ -36,7 +36,7 @@ describe Ingreedy::Rationalizer do
   context 'with the word a or an' do
     it 'gives back a rational' do
       subject.rationalize(word: 'a').should == '1'.to_r
-      subject.rationalize(word: 'an').should == '1'.to_r
+      subject.rationalize(word: 'AN').should == '1'.to_r
     end
   end
 


### PR DESCRIPTION
Found that mixed case and upper case units are not being converted to numbers. eg. 'UN KILO'

this PR makes sure to downcase words before rationalizing them