### PR TITLE
prevent word digit parser from picking up words inside ingredients

### DIFF
--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
  s.description = "Natural language recipe ingredient parser that supports numeric amount, units, and ingredient"
  s.homepage    = "http://github.com/iancanderson/ingreedy"
 
- s.add_dependency 'parslet', '~> 1.5.0'
+ s.add_dependency 'parslet', '~> 1.7.0'
 
  s.add_development_dependency 'rake', '~> 0.9'
  s.add_development_dependency 'rspec', '~> 2.11.0'

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -41,9 +41,9 @@ module Ingreedy
 
     rule(:amount) do
       fraction |
-        float.as(capture_key(:float_amount)) |
-        integer.as(capture_key(:integer_amount)) |
-        word_digit.as(capture_key(:word_integer_amount)) >> amount_unit_separator
+      float.as(capture_key(:float_amount)) |
+      integer.as(capture_key(:integer_amount)) |
+      word_digit.as(capture_key(:word_integer_amount)) >> amount_unit_separator
     end
 
     root(:amount)

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -35,11 +35,15 @@ module Ingreedy
       word_digits.map { |d| stri(d) }.inject(:|) || any
     end
 
+    rule(:amount_unit_separator) do
+      whitespace | str('-')
+    end
+
     rule(:amount) do
       fraction |
         float.as(capture_key(:float_amount)) |
         integer.as(capture_key(:integer_amount)) |
-        word_digit.as(capture_key(:word_integer_amount))
+        word_digit.as(capture_key(:word_integer_amount)) >> amount_unit_separator
     end
 
     root(:amount)

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -67,13 +67,14 @@ module Ingreedy
     end
 
     rule(:standard_format) do
+      # (word_digit || number) >> unit_and_preposition >> ingredients
       # e.g. 1/2 (12 oz) can black beans
       amount_and_unit >> any.repeat.as(:ingredient)
     end
 
     rule(:reverse_format) do
       # e.g. flour 200g
-      (amount.absent? >> any).repeat.as(:ingredient) >> amount_and_unit
+      ((whitespace >> amount_and_unit).absent? >> any).repeat.as(:ingredient) >> whitespace >> amount_and_unit
     end
 
     rule(:ingredient_addition) do

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -54,7 +54,7 @@ module Ingreedy
       # e.g. (12 ounce) or 12 ounce
       str('(').maybe >>
       container_amount.as(:container_amount) >>
-      amount_unit_separator >>
+      amount_unit_separator.maybe >>
       container_unit.as(:unit) >>
       str(')').maybe >> whitespace
     end

--- a/spec/ingreedy/amount_parser_spec.rb
+++ b/spec/ingreedy/amount_parser_spec.rb
@@ -4,8 +4,9 @@ describe Ingreedy::AmountParser do
 
   context 'given mixed case insensitive english words' do
     %w|one two three four five six seven eight nine ten eleven twelve|.each do |word|
-      it %Q|parses a lowercase "#{word}"| do
-        subject.should parse(word)
+      word += ' '
+      it %Q|parses a lowercase "#{word}" followed by space| do
+        subject.should parse(word )
       end
 
       it %Q|parses a uppercase "#{word}"| do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -245,7 +245,7 @@ describe "with 'a' as quantity and preposition 'of'" do
 end
 
 describe "with 'reverse format'" do
-  before(:all) { @ingreedy = Ingreedy.parse "flour 200g" }
+  before(:all) { @ingreedy = Ingreedy.parse "salt 200g" }
 
   it "should have the correct amount" do
     @ingreedy.amount.should == 200
@@ -256,7 +256,7 @@ describe "with 'reverse format'" do
   end
 
   it "should have the correct ingredient" do
-    @ingreedy.ingredient.should == "flour"
+    @ingreedy.ingredient.should == "salt"
   end
 end
 

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -245,18 +245,18 @@ describe "with 'a' as quantity and preposition 'of'" do
 end
 
 describe "with 'reverse format'" do
-  before(:all) { @ingreedy = Ingreedy.parse "salt 200g" }
-
-  it "should have the correct amount" do
+  it "should work with words containing a 'word digit'" do
+    @ingreedy = Ingreedy.parse "salt 200g"
     @ingreedy.amount.should == 200
-  end
-
-  it "should have the correct unit" do
     @ingreedy.unit.should == :gram
+    @ingreedy.ingredient.should == "salt"
   end
 
-  it "should have the correct ingredient" do
-    @ingreedy.ingredient.should == "salt"
+  it "should work with words ending on a 'word digit'" do
+    @ingreedy = Ingreedy.parse "quinoa 200g"
+    @ingreedy.amount.should == 200
+    @ingreedy.unit.should == :gram
+    @ingreedy.ingredient.should == "quinoa"
   end
 end
 


### PR DESCRIPTION
Turns out the conversion of words to digits that would allow things like "a cup of flour" would also pick up the "a" in "salt" when writing ingredients in reverse format ie "salt 200g"!

I've solved it by requiring that a word digit is always followed by a space (ie "an onion") or hyphen ("two-ounce can"), under the assumption that we would never see (or be able to parse accurately) something like "anonion" or "twograms of potatoes".

Don't know if that makes sense...? :sweat_smile: 

