### PR TITLE
Support "approximate quantities"

### DIFF
--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
  s.description = "Natural language recipe ingredient parser that supports numeric amount, units, and ingredient"
  s.homepage    = "http://github.com/iancanderson/ingreedy"
 
- s.add_dependency 'parslet', '~> 1.5.0'
+ s.add_dependency 'parslet', '~> 1.7.0'
 
  s.add_development_dependency 'rake', '~> 0.9'
  s.add_development_dependency 'rspec', '~> 2.11.0'

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -41,9 +41,9 @@ module Ingreedy
 
     rule(:amount) do
       fraction |
-        float.as(capture_key(:float_amount)) |
-        integer.as(capture_key(:integer_amount)) |
-        word_digit.as(capture_key(:word_integer_amount)) >> amount_unit_separator
+      float.as(capture_key(:float_amount)) |
+      integer.as(capture_key(:integer_amount)) |
+      word_digit.as(capture_key(:word_integer_amount)) >> amount_unit_separator
     end
 
     root(:amount)

--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -35,11 +35,15 @@ module Ingreedy
       word_digits.map { |d| stri(d) }.inject(:|) || any
     end
 
+    rule(:amount_unit_separator) do
+      whitespace | str('-')
+    end
+
     rule(:amount) do
       fraction |
         float.as(capture_key(:float_amount)) |
         integer.as(capture_key(:integer_amount)) |
-        word_digit.as(capture_key(:word_integer_amount))
+        word_digit.as(capture_key(:word_integer_amount)) >> amount_unit_separator
     end
 
     root(:amount)

--- a/lib/ingreedy/dictionaries/en.yml
+++ b/lib/ingreedy/dictionaries/en.yml
@@ -100,6 +100,8 @@
   :can:
     - "cans"
     - "can"
+  :to_taste:
+    - "to taste"
 :numbers:
   a: 1
   an: 1

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -67,13 +67,14 @@ module Ingreedy
     end
 
     rule(:standard_format) do
+      # (word_digit || number) >> unit_and_preposition >> ingredients
       # e.g. 1/2 (12 oz) can black beans
       amount_and_unit >> any.repeat.as(:ingredient)
     end
 
     rule(:reverse_format) do
       # e.g. flour 200g
-      (amount.absent? >> any).repeat.as(:ingredient) >> amount_and_unit
+      ((whitespace >> amount_and_unit).absent? >> any).repeat.as(:ingredient) >> whitespace >> amount_and_unit
     end
 
     rule(:ingredient_addition) do

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -66,15 +66,19 @@ module Ingreedy
       container_size.maybe
     end
 
+    rule(:quantity) do
+      amount_and_unit | unit_and_preposition
+    end
+
     rule(:standard_format) do
       # (word_digit || number) >> unit_and_preposition >> ingredients
       # e.g. 1/2 (12 oz) can black beans
-      amount_and_unit >> any.repeat.as(:ingredient)
+      quantity >> any.repeat.as(:ingredient)
     end
 
     rule(:reverse_format) do
       # e.g. flour 200g
-      ((whitespace >> amount_and_unit).absent? >> any).repeat.as(:ingredient) >> whitespace >> amount_and_unit
+      ((whitespace >> quantity).absent? >> any).repeat.as(:ingredient) >> whitespace >> quantity
     end
 
     rule(:ingredient_addition) do
@@ -123,6 +127,7 @@ module Ingreedy
     end
 
     def rationalize_amount(amount, capture_key_prefix = '')
+      return unless amount
       integer = amount["#{capture_key_prefix}integer_amount".to_sym]
       integer &&= integer.to_s
 

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -29,17 +29,17 @@ module Ingreedy
     end
 
     rule(:unit_and_preposition) do
-      unit.as(:unit) >> (preposition | whitespace | any.absent?)
+      if prepositions.empty?
+        unit.as(:unit) >> (whitespace | any.absent?)
+      else
+        unit.as(:unit) >> (preposition | whitespace | any.absent?)
+      end
     end
 
     rule(:preposition) do
-      if prepositions.empty?
-        any
-      else
-        whitespace >>
-        prepositions.map { |con| str(con) }.inject(:|) >>
-        whitespace
-      end
+      whitespace >>
+      prepositions.map { |con| str(con) }.inject(:|) >>
+      whitespace
     end
 
     rule(:container_unit) do
@@ -71,7 +71,6 @@ module Ingreedy
     end
 
     rule(:standard_format) do
-      # (word_digit || number) >> unit_and_preposition >> ingredients
       # e.g. 1/2 (12 oz) can black beans
       quantity >> any.repeat.as(:ingredient)
     end

--- a/lib/ingreedy/ingreedy_parser.rb
+++ b/lib/ingreedy/ingreedy_parser.rb
@@ -54,7 +54,7 @@ module Ingreedy
       # e.g. (12 ounce) or 12 ounce
       str('(').maybe >>
       container_amount.as(:container_amount) >>
-      amount_unit_separator >>
+      amount_unit_separator.maybe >>
       container_unit.as(:unit) >>
       str(')').maybe >> whitespace
     end

--- a/spec/ingreedy/amount_parser_spec.rb
+++ b/spec/ingreedy/amount_parser_spec.rb
@@ -4,8 +4,9 @@ describe Ingreedy::AmountParser do
 
   context 'given mixed case insensitive english words' do
     %w|one two three four five six seven eight nine ten eleven twelve|.each do |word|
-      it %Q|parses a lowercase "#{word}"| do
-        subject.should parse(word)
+      word += ' '
+      it %Q|parses a lowercase "#{word}" followed by space| do
+        subject.should parse(word )
       end
 
       it %Q|parses a uppercase "#{word}"| do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -245,7 +245,7 @@ describe "with 'a' as quantity and preposition 'of'" do
 end
 
 describe "with 'reverse format'" do
-  before(:all) { @ingreedy = Ingreedy.parse "flour 200g" }
+  before(:all) { @ingreedy = Ingreedy.parse "salt 200g" }
 
   it "should have the correct amount" do
     @ingreedy.amount.should == 200
@@ -256,7 +256,7 @@ describe "with 'reverse format'" do
   end
 
   it "should have the correct ingredient" do
-    @ingreedy.ingredient.should == "flour"
+    @ingreedy.ingredient.should == "salt"
   end
 end
 

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -227,7 +227,6 @@ describe "without units" do
   end
 end
 
-
 describe "with 'a' as quantity and preposition 'of'" do
   before(:all) { @ingreedy = Ingreedy.parse "a dash of ginger" }
 
@@ -266,6 +265,31 @@ describe "with 'reverse format'" do
     @ingreedy.unit.should == :to_taste
   end
 end
+
+describe "parsing in language with no prepositions" do
+  before(:all) do
+    Ingreedy.dictionaries[:id] = { units: { to_taste: ['secukupnya'], gram: ['g'] } }
+    Ingreedy.locale = :id
+    @ingreedy = Ingreedy.parse "garam secukupnya"
+  end
+
+  after(:all) do
+    Ingreedy.locale = nil
+  end
+
+  it "should have a nil amount" do
+    @ingreedy.amount.should be_nil
+  end
+
+  it "should have the correct  unit" do
+    @ingreedy.unit.should == :to_taste
+  end
+
+  it "should have the correct ingredient" do
+    @ingreedy.ingredient.should == "garam"
+  end
+end
+
 
 describe "custom dictionaries" do
   context "using Ingreedy.locale=" do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -258,6 +258,13 @@ describe "with 'reverse format'" do
     @ingreedy.unit.should == :gram
     @ingreedy.ingredient.should == "quinoa"
   end
+
+  it "should work with approximate quantities" do
+    @ingreedy = Ingreedy.parse "salt to taste"
+    @ingreedy.ingredient.should == "salt"
+    @ingreedy.amount.should be_nil
+    @ingreedy.unit.should == :to_taste
+  end
 end
 
 describe "custom dictionaries" do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -245,18 +245,18 @@ describe "with 'a' as quantity and preposition 'of'" do
 end
 
 describe "with 'reverse format'" do
-  before(:all) { @ingreedy = Ingreedy.parse "salt 200g" }
-
-  it "should have the correct amount" do
+  it "should work with words containing a 'word digit'" do
+    @ingreedy = Ingreedy.parse "salt 200g"
     @ingreedy.amount.should == 200
-  end
-
-  it "should have the correct unit" do
     @ingreedy.unit.should == :gram
+    @ingreedy.ingredient.should == "salt"
   end
 
-  it "should have the correct ingredient" do
-    @ingreedy.ingredient.should == "salt"
+  it "should work with words ending on a 'word digit'" do
+    @ingreedy = Ingreedy.parse "quinoa 200g"
+    @ingreedy.amount.should == 200
+    @ingreedy.unit.should == :gram
+    @ingreedy.ingredient.should == "quinoa"
   end
 end
 


### PR DESCRIPTION
Sorry to submit another PR without the first one having been reviewed yet! :sweat: 

This depends on #15 so the diff might be a bit hard to evaluate...might be better to look at the diff between the two: https://github.com/balvig/ingreedy/compare/salt...balvig:approx

This change adds support for quantities that have "no number", such as "to taste", "as needed" etc:

```ruby
@ingreedy = Ingreedy.parse "salt to taste"
@ingreedy.ingredient.should == "salt"
@ingreedy.amount.should be_nil
@ingreedy.unit.should == :to_taste
```

This also required compensating for a bug that would occur for for dictionaries that contained no prepositions: https://github.com/iancanderson/ingreedy/commit/33d69fafdf8c59d855a051dfb6ca9425834ce526