### PR TITLE
Fix tests for RSpec 3

### DIFF
--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
  s.add_dependency 'parslet', '~> 1.5.0'
 
  s.add_development_dependency 'rake', '~> 0.9'
- s.add_development_dependency 'rspec', '~> 2.11.0'
+ s.add_development_dependency 'rspec', '~> 3.3.0'
+ s.add_development_dependency 'rspec-its', '~> 1.2.0'
  s.add_development_dependency 'coveralls', '~> 0.7.0'
  s.add_development_dependency 'pry'
  s.files       = Dir.glob("lib/**/*.rb")

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -286,9 +286,8 @@ describe "custom dictionaries" do
   end
 
   context "using I18n.locale" do
-    before(:all) do
+    before(:each) do
       Ingreedy.dictionaries[:de] = { units: { dash: ['prise'] } }
-      RSpec::Mocks::setup(self)
       stub_const 'I18n', double('I18n', locale: :de)
       @ingreedy = Ingreedy.parse "1 Prise Zucker"
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,13 @@ end
 require 'ingreedy'
 require 'parslet/rig/rspec'
 require 'pry'
+require 'rspec/its'
 
 RSpec::Matchers.define :parse_the_unit do |unit|
   match do |ingreedy_output|
     ingreedy_output.unit == unit
   end
-  failure_message_for_should do |ingreedy_output|
+  failure_message do |ingreedy_output|
     "expected to parse the unit #{unit} from the query '#{ingreedy_output.original_query}' " +
     "got '#{ingreedy_output.unit}' instead"
   end
@@ -21,7 +22,7 @@ RSpec::Matchers.define :parse_the_amount do |amount|
   match do |ingreedy_output|
     ingreedy_output.amount == amount
   end
-  failure_message_for_should do |ingreedy_output|
+  failure_message do |ingreedy_output|
     "expected to parse the amount #{amount} from the query '#{ingreedy_output.original_query}.' " +
     "got '#{ingreedy_output.amount}' instead"
   end


### PR DESCRIPTION
The tests were failing because the `its` syntax is no longer part of RSpec.

I also had to make a small change to prevent the failure:

`The use of doubles or partial doubles from rspec-mocks outside of the
per-test lifecycle is not supported.`