### PR TITLE
Support tilde in ranges

### DIFF
--- a/lib/ingreedy/amount_parser.rb
+++ b/lib/ingreedy/amount_parser.rb
@@ -47,15 +47,11 @@ module Ingreedy
       word_digits.map { |d| stri(d) }.inject(:|) || any
     end
 
-    rule(:amount_unit_separator) do
-      whitespace | str("-")
-    end
-
     rule(:amount) do
       fraction |
         float.as(:float_amount) |
         integer.as(:integer_amount) |
-        word_digit.as(:word_integer_amount) >> amount_unit_separator
+        word_digit.as(:word_integer_amount) >> whitespace
     end
 
     root(:amount)

--- a/lib/ingreedy/root_parser.rb
+++ b/lib/ingreedy/root_parser.rb
@@ -3,9 +3,13 @@ module Ingreedy
     rule(:range) do
       AmountParser.new.as(:amount) >>
         whitespace.maybe >>
-        str("-") >>
+        range_separator >>
         whitespace.maybe >>
         AmountParser.new.as(:amount_end)
+    end
+
+    rule(:range_separator) do
+      str("-") | str("~")
     end
 
     rule(:amount) do

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -272,6 +272,14 @@ describe Ingreedy, "Given a range" do
     expect(result.unit).to eq(:tablespoon)
     expect(result.ingredient).to eq("salt")
   end
+
+  it "works with tilde" do
+    result = Ingreedy.parse "1~2 tbsp salt"
+
+    expect(result.amount).to eq([1, 2])
+    expect(result.unit).to eq(:tablespoon)
+    expect(result.ingredient).to eq("salt")
+  end
 end
 
 describe Ingreedy, "parsing in language with no prepositions" do


### PR DESCRIPTION
Supports stuff like "1~3 tbsp sugar". Perhaps having the different kind of "range separators" in the dictionary will make sense at some point?

The deleted code from `amount_parser.rb` was seemingly unused and confused me when I went hunting for the hyphen in ranges :sweat_smile:  I decided to take it out, but not sure if it's required for something?