### PR TITLE
Wrap Parslet exceptions

### DIFF
--- a/lib/ingreedy.rb
+++ b/lib/ingreedy.rb
@@ -5,6 +5,8 @@ require File.join(path, "ingreedy_parser")
 require File.join(path, "dictionary_collection")
 
 module Ingreedy
+  ParseFailed = Class.new(StandardError)
+
   def self.locale
     @locale ||= nil
   end
@@ -16,6 +18,8 @@ module Ingreedy
   def self.parse(query)
     parser = Parser.new(query)
     parser.parse
+  rescue Parslet::ParseFailed => e
+    fail ParseFailed.new(e.message), e.backtrace
   end
 
   def self.dictionaries

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -367,3 +367,11 @@ describe Ingreedy, "ingredient formatting" do
     expect(Ingreedy.parse("1 cup flour ").ingredient).to eq("flour")
   end
 end
+
+describe Ingreedy, "error handling" do
+  it "wraps Parslet exceptions in a custom exception" do
+    expect do
+      Ingreedy.parse("nonsense")
+    end.to raise_error Ingreedy::ParseFailed
+  end
+end


### PR DESCRIPTION
A Parslet exception is raised when attempting to parse invalid input.
This means the consumer of the gem needs to be concerned with its
internal implementation in order to rescue the failure.

By wrapping the Parslet exception we can avoid leaking this information.