### PR TITLE
Provide option for preserving amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ print result.ingredient
   #=> "sucre"
 ```
 
+### Handling amounts
+
+By default, Ingreedy will convert all amounts to a rational number:
+
+```ruby
+result = Ingreedy.parse("1 1/2 cups flour")
+print result.amount
+  #=> 3/2
+```
+
+However, setting `Ingreedy.preverse_amounts = true`, will allow amounts
+to be detected and returned as originally input:
+
+```ruby
+Ingreedy.preserve_amounts = true
+
+result = Ingreedy.parse("1 1/2 cups flour")
+print result.amount
+  #=> 1 1/2
+```
+
 [Live demo](http://hangryingreedytest.herokuapp.com/)
 
 # Pieces of Flair

--- a/lib/ingreedy.rb
+++ b/lib/ingreedy.rb
@@ -7,12 +7,8 @@ require File.join(path, "dictionary_collection")
 module Ingreedy
   ParseFailed = Class.new(StandardError)
 
-  def self.locale
-    @locale ||= nil
-  end
-
-  def self.locale=(locale)
-    @locale = locale
+  class << self
+    attr_accessor :locale, :preserve_amounts
   end
 
   def self.parse(query)

--- a/lib/ingreedy/rationalizer.rb
+++ b/lib/ingreedy/rationalizer.rb
@@ -12,44 +12,42 @@ module Ingreedy
     end
 
     def rationalize
-      if @word
-        result = normalized_word
-      elsif @fraction
-        result = rationalized_fraction
-      elsif @integer
-        result = @integer
-      elsif @float
-        result = rationalized_float
+      if Ingreedy.preserve_amounts
+        (normalized_word || compound_fraction || @float || @integer)
+      else
+        (normalized_word || rationalized_fraction || rationalized_float || @integer).to_r
       end
-
-      result.to_r
     end
 
     private
 
     def normalized_word
+      return unless @word
       Ingreedy.dictionaries.current.numbers[@word.downcase]
     end
 
     def normalized_fraction
       @fraction.tap do |fraction|
-        vulgar_fractions.each do |char, amount|
+        Ingreedy.dictionaries.current.vulgar_fractions.each do |char, amount|
           fraction.gsub!(char, amount.to_s)
         end
       end
     end
 
-    def vulgar_fractions
-      Ingreedy.dictionaries.current.vulgar_fractions
-    end
-
     def rationalized_fraction
+      return unless @fraction
       result = normalized_fraction
-      result = result.to_r + @integer.to_i if @integer
+      result = result.to_r + @integer.to_i
       result
     end
 
+    def compound_fraction
+      return unless @fraction
+      "#{@integer} #{normalized_fraction}".strip
+    end
+
     def rationalized_float
+      return unless @float
       @float.tr(",", ".")
     end
   end

--- a/lib/ingreedy/rationalizer.rb
+++ b/lib/ingreedy/rationalizer.rb
@@ -13,36 +13,44 @@ module Ingreedy
 
     def rationalize
       if @word
-        result = rationalize_word
+        result = normalized_word
       elsif @fraction
-        result = rationalize_fraction
-        if @integer
-          result += @integer.to_i
-        end
+        result = rationalized_fraction
       elsif @integer
-        result = @integer.to_r
+        result = @integer
       elsif @float
-        result = @float.tr(",", ".").to_r
+        result = rationalized_float
       end
 
-      result
+      result.to_r
     end
 
     private
 
-    def rationalize_fraction
-      vulgar_fractions.each do |char, amount|
-        @fraction.gsub!(char, amount.to_s)
+    def normalized_word
+      Ingreedy.dictionaries.current.numbers[@word.downcase]
+    end
+
+    def normalized_fraction
+      @fraction.tap do |fraction|
+        vulgar_fractions.each do |char, amount|
+          fraction.gsub!(char, amount.to_s)
+        end
       end
-      @fraction.to_r
     end
 
     def vulgar_fractions
       Ingreedy.dictionaries.current.vulgar_fractions
     end
 
-    def rationalize_word
-      Ingreedy.dictionaries.current.numbers[@word.downcase]
+    def rationalized_fraction
+      result = normalized_fraction
+      result = result.to_r + @integer.to_i if @integer
+      result
+    end
+
+    def rationalized_float
+      @float.tr(",", ".")
     end
   end
 end

--- a/spec/ingreedy_spec.rb
+++ b/spec/ingreedy_spec.rb
@@ -41,6 +41,32 @@ describe Ingreedy, "amount parsing" do
   end
 end
 
+describe Ingreedy, "amount parsing preserving original value" do
+  around do |example|
+    Ingreedy.preserve_amounts = true
+    example.run
+    Ingreedy.preserve_amounts = false
+  end
+
+  {
+    "1 cup flour" => "1",
+    "2 cups flour" => "2",
+    "1 1/2 cups flour" => "1 1/2",
+    "¼ cups flour" => "1/4",
+    "1 ½ cups flour" => "1 1/2",
+    "1½ cups flour" => "1 1/2",
+    "1.0 cup flour" => "1.0",
+    "1.5 cups flour" => "1.5",
+    "1,5 cups flour" => "1,5",
+    "1/2 cups flour" => "1/2",
+    ".25 cups flour" => ".25",
+  }.each do |query, expected|
+    it "parses the correct amount" do
+      expect(Ingreedy.parse(query).amount).to eq(expected)
+    end
+  end
+end
+
 describe Ingreedy, "english units" do
   context "abbreviated" do
     {


### PR DESCRIPTION
This provides an option to disable converting amounts to rational numbers, and preserve the original amount:

```ruby
result = Ingreedy.parse("1 1/2 cups flour")
print result.amount
  #=> 3/2

Ingreedy.preserve_amounts = true

result = Ingreedy.parse("1 1/2 cups flour")
print result.amount
  #=> 1 1/2
```

Use case is that while we would like to leverage the power of Ingreedy to _detect_ amounts (and normalize vulgar fractions etc), we also want to return the amounts unmodified, preserving what was originally input.

Hope that makes sense!