### PR TITLE
add support for UTF-8 [ready, waiting for review]

### DIFF
--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.require_path = "lib"
 
-  s.add_dependency "parslet", "~> 1.7.0", ">= 1.7.0"
+  s.add_dependency "parslet", "~> 1.8.0", ">= 1.8.0"
+  s.add_dependency "unicode", "~> 0.4.4", ">= 0.4.4"
 
   s.add_development_dependency "rake", "~> 0.9", ">= 0.9"
   s.add_development_dependency "rspec", "~> 3.3.0", ">= 3.3.0"

--- a/lib/ingreedy/case_insensitive_parser.rb
+++ b/lib/ingreedy/case_insensitive_parser.rb
@@ -1,9 +1,11 @@
+require 'unicode'
+
 module Ingreedy
   module CaseInsensitiveParser
     def stri(str)
       key_chars = str.split(//)
       key_chars.
-        map! { |char| match["#{char.upcase}#{char.downcase}"] }.
+        map! { |char| match["#{Unicode.upcase(char)}#{Unicode.downcase(char)}"] }.
         reduce(:>>)
     end
   end

--- a/lib/ingreedy/rationalizer.rb
+++ b/lib/ingreedy/rationalizer.rb
@@ -23,7 +23,7 @@ module Ingreedy
 
     def normalized_word
       return unless @word
-      Ingreedy.dictionaries.current.numbers[@word.downcase]
+      Ingreedy.dictionaries.current.numbers[Unicode.downcase(@word)]
     end
 
     def normalized_fraction


### PR DESCRIPTION
downcase, upcase is not working for letters like ę ("ę".upcase returns ę, it should return Ę)

It is workaround for https://bugs.ruby-lang.org/issues/10085