### PR TITLE
Add a test for russian language

### DIFF
--- a/spec/integrations/russian_spec.rb
+++ b/spec/integrations/russian_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "Russian language" do
+  before(:each) do
+    Ingreedy.dictionaries[:ru] = { units: { piece: ["шт"] } }
+    stub_const "I18n", double("I18n", locale: :ru)
+  end
+
+  it "parses correctly" do
+    result = Ingreedy.parse "Для: 1 шт яйцо" # For: 1 piece egg
+
+    expect(result.amount).to eq(1)
+    expect(result.unit).to eq(:piece)
+    expect(result.ingredient).to eq("яйцо")
+  end
+end

--- a/spec/integrations/russian_spec.rb
+++ b/spec/integrations/russian_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "Russian language" do
   before(:each) do
     Ingreedy.dictionaries[:ru] = { units: { piece: ["шт"] } }


### PR DESCRIPTION
Trying to figure out why this failed.

backtrace:

```
Failure/Error: result = Ingreedy.parse "Для: 1 шт яйцо" # For: 1 piece egg
     Ingreedy::ParseFailed:
       ["/Users/juanito-fatas/.gem/ruby/2.3.2/gems/parslet-1.7.1/lib/parslet/cause.rb:70:in `raise'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/parslet-1.7.1/lib/parslet/atoms/base.rb:49:in `parse'", "/Users/juanito-fatas/dev/ingreedy/lib/ingreedy/root_parser.rb:104:in `parse'", "/Users/juanito-fatas/dev/ingreedy/lib/ingreedy/ingreedy_parser.rb:29:in `parse'", "/Users/juanito-fatas/dev/ingreedy/lib/ingreedy.rb:16:in `parse'", "/Users/juanito-fatas/dev/ingreedy/spec/integrations/russian_spec.rb:8:in `block (2 levels) in <top (required)>'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example.rb:206:in `instance_exec'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example.rb:206:in `block in run'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example.rb:430:in `block in with_around_and_singleton_context_hooks'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example.rb:388:in `block in with_around_example_hooks'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/hooks.rb:478:in `block in run'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/hooks.rb:616:in `run_around_example_hooks_for'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/hooks.rb:478:in `run'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example.rb:388:in `with_around_example_hooks'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example.rb:430:in `with_around_and_singleton_context_hooks'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example.rb:203:in `run'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:559:in `block in run_examples'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:555:in `map'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:555:in `run_examples'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/example_group.rb:521:in `run'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:115:in `block (3 levels) in run_specs'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:115:in `map'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:115:in `block (2 levels) in run_specs'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1627:in `with_suite_hooks'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:114:in `block in run_specs'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/reporter.rb:77:in `report'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:113:in `run_specs'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:89:in `run'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'", "/Users/juanito-fatas/.gem/ruby/2.3.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"]
```

The real error is:

```
Parslet::ParseFailed: Expected one of [IMPRECISE, STANDARD_FORMAT, REVERSE_FORMAT]
at line 1 char 1.
```