### PR TITLE
Add support for parslet 2.x

### DIFF
--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.require_path = "lib"
 
-  s.add_dependency "parslet", "~> 1.7.0", ">= 1.7.0"
+  s.add_dependency "parslet", ">= 1.7.0", "< 3"
 
   s.add_development_dependency "rake", "~> 0.9", ">= 0.9"
   s.add_development_dependency "rspec", "~> 3.3.0", ">= 3.3.0"


### PR DESCRIPTION
From https://github.com/kschiess/parslet/blob/master/HISTORY.txt:
>   This release is essentially what is called a 'done' release, meaning I consider
  that parslet meets its goals and doesn't need (much) more evolution. 

I'm blocked from updating `parslet` by this constraint so I would like to relax it