### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - head
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - jruby
+    continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == 'jruby' }}
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---color
+--force-color

--- a/ingreedy.gemspec
+++ b/ingreedy.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "parslet", "~> 1.7.0", ">= 1.7.0"
 
-  s.add_development_dependency "rake", "~> 0.9", ">= 0.9"
-  s.add_development_dependency "rspec", "~> 3.3.0", ">= 3.3.0"
-  s.add_development_dependency "coveralls", "~> 0.7.0", ">= 0.7.0"
+  s.add_development_dependency "rake", "~> 13"
+  s.add_development_dependency "rspec", "~> 3.10"
+  s.add_development_dependency "coveralls_reborn", "~> 0.22"
   s.add_development_dependency "pry"
 end


### PR DESCRIPTION
Travis CI's open source support is deprecated and jobs stay in the queue significantly longer now. 

Github Actions is faster, still free, and built-in to Github.

Here's a passing build on my fork: https://github.com/mlarraz/ingreedy/actions/runs/1098366050

Note that the build won't trigger on the base repo until this PR is merged, so keeping around Travis until then. See https://github.com/mhuggins/ruby-measurement/pull/20 for a recent example on another repo.